### PR TITLE
fix: jump delay

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,7 +11,7 @@ function jump () {
     }
     setTimeout( function() {
         dino.classList.remove("jump")
-    }, 300)
+    }, 900)
 }
 
 let isAlive = setInterval ( function() {


### PR DESCRIPTION
In style.css file you have the animation jump, so this animation need time to play full. When you start but didn't done yet, you can try "jump" again. Well it tryes to play animation and with delay remove it, but animation need more than 300ms, so it's 1000ms in style. 

The player will like it more if the game reacts faster, so 900ms is fune.